### PR TITLE
Fix bug where file is undefined on finish in newer mongodb versions

### DIFF
--- a/src/gridFile.schema.js
+++ b/src/gridFile.schema.js
@@ -240,6 +240,9 @@ schema.method('upload', function (stream, callback) {
     })
 
     uploadStream.on('finish', (file) => {
+      if(!file) {
+        file = uploadStream.gridFSFile
+      }
       const document = this.model.hydrate(file)
 
       resolve(document)


### PR DESCRIPTION
This fixes an issue where the callback function in the `finish` event of uploadStream does not receive the file object in the latest versions of MongoDB. It seems that in mongo db 6.6 the API is different. (See https://mongodb.github.io/node-mongodb-native/6.6/classes/GridFSBucketWriteStream.html#gridFSFile)

This change preserves backward compatibility by retrieving the file object from `uploadStream.gridFSFile` if it wasn't passed directly to the callback.